### PR TITLE
Allow flash requests to be detected. For https://webarchive.jira.com/browse/ARI-3724

### DIFF
--- a/umbra/browser.py
+++ b/umbra/browser.py
@@ -203,7 +203,8 @@ class Chrome:
                 "--disable-web-sockets", "--disable-cache",
                 "--window-size=1100,900", "--no-default-browser-check",
                 "--disable-first-run-ui", "--no-first-run",
-                "--homepage=about:blank", "about:blank"]
+                "--homepage=about:blank", "--disable-direct-npapi-requests",
+                "about:blank"]
         self.logger.info("running {}".format(chrome_args))
         self.chrome_process = subprocess.Popen(chrome_args, env=new_env, start_new_session=True)
         self.logger.info("chrome running, pid {}".format(self.chrome_process.pid))


### PR DESCRIPTION
It looks like requests generated for flash aren't detected by the chromium debugger protocol. You can see this behaviour by opening chromium, going to a flash site, and checking the dev tools windows for swf requests. There aren't any. Adding "--disable-direct-npapi-requests" (described at https://code.google.com/p/chromium/issues/detail?id=319203) allows these requests to be detected.
