### PR TITLE
Allow default behavior to include clicking on sound cloud player buttons embbedded in 3rd party sites.

### DIFF
--- a/umbra/behaviors.d/default.js
+++ b/umbra/behaviors.d/default.js
@@ -18,7 +18,7 @@ var umbraAboveBelowOrOnScreen = function(e) {
 
 var umbraState = {'idleSince':null};
 var umbraAlreadyClicked = {};
-var UMBRA_IFRAME_SOUNDCLOUD_EMBEDDED_SELECTOR = "iframe[src^='https://w.soundcloud.com/player']";
+var UMBRA_IFRAME_SOUNDCLOUD_EMBEDDED_SELECTOR = "iframe[src^='http://w.soundcloud.com/player'], iframe[src^='https://w.soundcloud.com/player']";
 var UMBRA_THINGS_TO_CLICK_SOUNDCLOUD_EMBEDDED_SELECTOR = "button.playButton";
 var umbraFinished = false;
 var umbraIntervalFunc = function() {
@@ -89,18 +89,16 @@ var getUmbraSoundCloudEmbeddedElements = function() {
 	
 	[].forEach.call(document.querySelectorAll(UMBRA_IFRAME_SOUNDCLOUD_EMBEDDED_SELECTOR), 
 		function  fn(elem){ 
-			if (elem.src.indexOf("auto_play=false") != -1) {
-				    var button = elem.contentWindow.document.body.querySelectorAll(UMBRA_THINGS_TO_CLICK_SOUNDCLOUD_EMBEDDED_SELECTOR);
-				   
-				    //use the iframe's src attribute as the key to the sound cloud player button. assumption is that each iframe created by the sound cloud widget
-				    //contains only a single unique audio file on a given page
-					if (button && button.length > 0) {
-						//get the Element from the NodeList
-						soundCloudEmbeddedElements.push({"id" : elem.src, "target" : button.item(0)});
-						id++;
-					}
-			    }
+		    var button = elem.contentWindow.document.body.querySelectorAll(UMBRA_THINGS_TO_CLICK_SOUNDCLOUD_EMBEDDED_SELECTOR);
+		   
+		    //use the iframe's src attribute as the key to the sound cloud player button. assumption is that each iframe created by the sound cloud widget
+		    //contains only a single unique audio file on a given page
+			if (button && button.length > 0) {
+				//get the Element from the NodeList
+				soundCloudEmbeddedElements.push({"id" : elem.src, "target" : button.item(0)});
+				id++;
 			}
+	    }
 	);
 	
 	return soundCloudEmbeddedElements;

--- a/umbra/behaviors.d/default.js
+++ b/umbra/behaviors.d/default.js
@@ -5,18 +5,105 @@
 // Scrolls to the bottom of the page. That's it at the moment.
 //
 
+var umbraAboveBelowOrOnScreen = function(e) {
+        var eTop = e.getBoundingClientRect().top;
+        if (eTop < window.scrollY) {
+                return -1; // above
+        } else if (eTop > window.scrollY + window.innerHeight) {
+                return 1;  // below
+        } else {
+                return 0;  // on screen
+        }
+}
+
 var umbraState = {'idleSince':null};
+var umbraAlreadyClicked = {};
+var UMBRA_IFRAME_SOUNDCLOUD_EMBEDDED_SELECTOR = "iframe[src^='https://w.soundcloud.com/player']";
+var UMBRA_THINGS_TO_CLICK_SOUNDCLOUD_EMBEDDED_SELECTOR = "button.playButton";
 var umbraFinished = false;
 var umbraIntervalFunc = function() {
-	var needToScroll = (window.scrollY + window.innerHeight < document.documentElement.scrollHeight);
 
-        // console.log('intervalFunc umbraState.idleSince=' + umbraState.idleSince + ' needToScroll=' + needToScroll + ' window.scrollY=' + window.scrollY + ' window.innerHeight=' + window.innerHeight + ' document.documentElement.scrollHeight=' + document.documentElement.scrollHeight);
-	if (needToScroll) {
-		window.scrollBy(0, 200);
-		umbraState.idleSince = null;
-	} else if (umbraState.idleSince == null) {
+	var umbraSoundCloudEmbeddedElements = getUmbraSoundCloudEmbeddedElements();
+	
+    var clickedSomething = false;
+    var somethingLeftBelow = false;
+    var somethingLeftAbove = false;
+    var missedAbove = 0;
+    
+    for (var i = 0; i < umbraSoundCloudEmbeddedElements.length; i++) {
+    
+    		var targetId = umbraSoundCloudEmbeddedElements[i].id;
+            var target = umbraSoundCloudEmbeddedElements[i].target;
+            
+            if (!(targetId in umbraAlreadyClicked)) {
+                    var where = umbraAboveBelowOrOnScreen(target);
+                    
+                    if (where == 0) { // on screen
+                            // var pos = target.getBoundingClientRect().top;
+                            // window.scrollTo(0, target.getBoundingClientRect().top - 100);
+                            console.log("clicking at " + target.getBoundingClientRect().top + " on " + target.outerHTML);
+                            if (target.click != undefined) {
+                                    target.click();
+                            }
+                            umbraAlreadyClicked[targetId] = true;
+                            clickedSomething = true;
+                            umbraState.idleSince = null;
+                            break;
+                    } else if (where > 0) { 
+                            somethingLeftBelow = true;
+                    } else if (where < 0) {
+                            somethingLeftAbove = true;
+                    }
+            }
+    }
+    
+    if (!clickedSomething) {
+        if (somethingLeftAbove) {
+                console.log("scrolling UP because everything on this screen has been clicked but we missed something above");
+                window.scrollBy(0, -500);
+                umbraState.idleSince = null;
+        } else if (somethingLeftBelow) {
+                console.log("scrolling because everything on this screen has been clicked but there's more below document.body.clientHeight=" + document.body.clientHeight);
+                window.scrollBy(0, 200);
+                umbraState.idleSince = null;
+        } else if (window.scrollY + window.innerHeight < document.documentElement.scrollHeight) {
+                console.log("scrolling because we're not to the bottom yet document.body.clientHeight=" + document.body.clientHeight);
+                window.scrollBy(0, 200);
+                umbraState.idleSince = null;
+        } else if (umbraState.idleSince == null) {
                 umbraState.idleSince = Date.now();
         }
+    }
+	
+	if (umbraState.idleSince == null) {
+                umbraState.idleSince = Date.now();
+    }
+}
+
+//try to detect sound cloud "Play" buttons and return them as targets for clicking
+var getUmbraSoundCloudEmbeddedElements = function() {
+	
+	var soundCloudEmbeddedElements = [];
+	
+	var id = 0;
+	
+	[].forEach.call(document.querySelectorAll(UMBRA_IFRAME_SOUNDCLOUD_EMBEDDED_SELECTOR), 
+		function  fn(elem){ 
+			if (elem.src.indexOf("auto_play=false") != -1) {
+				    var button = elem.contentWindow.document.body.querySelectorAll(UMBRA_THINGS_TO_CLICK_SOUNDCLOUD_EMBEDDED_SELECTOR);
+				   
+				    //use the iframe's src attribute as the key to the sound cloud player button. assumption is that each iframe created by the sound cloud widget
+				    //contains only a single unique audio file on a given page
+					if (button && button.length > 0) {
+						//get the Element from the NodeList
+						soundCloudEmbeddedElements.push({"id" : elem.src, "target" : button.item(0)});
+						id++;
+					}
+			    }
+			}
+	);
+	
+	return soundCloudEmbeddedElements;
 }
 
 // If we haven't had anything to do (scrolled, clicked, etc) in this amount of

--- a/umbra/behaviors.d/default.js
+++ b/umbra/behaviors.d/default.js
@@ -34,7 +34,7 @@ var umbraIntervalFunc = function() {
     
     for (var i = 0; i < umbraSoundCloudEmbeddedElements.length; i++) {
     
-    		var targetId = umbraSoundCloudEmbeddedElements[i].id;
+            var targetId = umbraSoundCloudEmbeddedElements[i].id;
             var target = umbraSoundCloudEmbeddedElements[i].target;
             
             if (!(targetId in umbraAlreadyClicked)) {

--- a/umbra/behaviors.d/default.js
+++ b/umbra/behaviors.d/default.js
@@ -84,7 +84,8 @@ var umbraIntervalFunc = function() {
 }
 
 //try to detect sound cloud "Play" buttons and return them as targets for clicking
-var getUmbraSoundCloudEmbeddedElements = function(soundCloudEmbeddedElements, currentIframeDepth, currentDocument) {
+var getUmbraSoundCloudEmbeddedElements = function(soundCloudEmbeddedElements, currentIframeDepth, currentDocument,
+		iframeElement) {
 	
 	//set default values for parameters
 	currentIframeDepth = currentIframeDepth || 0;
@@ -99,8 +100,10 @@ var getUmbraSoundCloudEmbeddedElements = function(soundCloudEmbeddedElements, cu
 	
 	button = currentDocument.querySelectorAll(UMBRA_THINGS_TO_CLICK_SOUNDCLOUD_EMBEDDED_SELECTOR);
 
+	var cssPathIframe = iframeElement ? getElementCssPath(iframeElement) : "";
+	
 	for (var i = 0; i < button.length; i++) {
-		soundCloudEmbeddedElements.push({"id" : getElementCssPath(button.item(i)), "target" : button.item(i)});
+		soundCloudEmbeddedElements.push({"id" : cssPathIframe + getElementCssPath(button.item(i)), "target" : button.item(i)});
 	}
 	
 	//now get all buttons in embedded iframes
@@ -109,7 +112,7 @@ var getUmbraSoundCloudEmbeddedElements = function(soundCloudEmbeddedElements, cu
 	iframe = currentDocument.querySelectorAll(UMBRA_IFRAME_SOUNDCLOUD_EMBEDDED_SELECTOR);
 	
 	for (var i = 0; i < iframe.length; i++) {
-		getUmbraSoundCloudEmbeddedElements(soundCloudEmbeddedElements, currentIframeDepth + 1, iframe[i].contentWindow.document.body);
+		getUmbraSoundCloudEmbeddedElements(soundCloudEmbeddedElements, currentIframeDepth + 1, iframe[i].contentWindow.document.body, iframe[i]);
 	}
 }
 

--- a/umbra/behaviors.d/default.js
+++ b/umbra/behaviors.d/default.js
@@ -23,9 +23,9 @@ var umbraAlreadyClicked = {};
 var umbraFinished = false;
 var umbraIntervalFunc = function() {
 
-	var umbraSoundCloudEmbeddedElements = [];
+    var umbraSoundCloudEmbeddedElements = [];
 
-	getUmbraSoundCloudEmbeddedElements(umbraSoundCloudEmbeddedElements);
+    getUmbraSoundCloudEmbeddedElements(umbraSoundCloudEmbeddedElements);
 	
     var clickedSomething = false;
     var somethingLeftBelow = false;

--- a/umbra/browser.py
+++ b/umbra/browser.py
@@ -241,6 +241,7 @@ class Chrome:
                 "--window-size=1100,900", "--no-default-browser-check",
                 "--disable-first-run-ui", "--no-first-run",
                 "--homepage=about:blank", "--disable-direct-npapi-requests",
+                "--disable-web-security",
                 "about:blank"]
         self.logger.info("running {}".format(chrome_args))
         self.chrome_process = subprocess.Popen(chrome_args, env=new_env, start_new_session=True)


### PR DESCRIPTION
Modelled the default behaviour on facebook behaviour. Default behaviour will try to detect SoundCloud player buttons and click them, which will capture the url of the audio file. Also added --disable-web-security to browser.py since accessing an iframe on a different domain than the parent domain throws a security exception without this setting. Not sure what the security implications of this are though. Needs some thought before merging.