### PR TITLE
Allow scrolling down a timeline in the facebook plugin so as to capture content in third party embedded timelines.

### DIFF
--- a/umbra/behaviors.d/facebook.js
+++ b/umbra/behaviors.d/facebook.js
@@ -33,13 +33,16 @@ var umbraState = {'idleSince':null,'expectingSomething':null,'bottomReachedScrol
 var umbraIntervalFunc = function() {
 	
 		var thingsToScroll = document.querySelectorAll(UMBRA_THINGS_TO_SCROLL_SELECTOR);
+		var everythingScrolled = true;
 		
 		for (var i = 0; i < thingsToScroll.length; i++) {
 			var target = thingsToScroll[i];
 			
-			if (!(target in umbraAlreadyScrolledThing)) {				
+			if (!(target in umbraAlreadyScrolledThing)) {
 				
-				console.log("scrolling to " + target.scrollHeight + " on element of type " + target.nodeName + " with id of " + target.id);
+				everythingScrolled = false;
+				
+				console.log("scrolling to " + target.scrollHeight + " on element with nodeName " + target.nodeName + " with id of " + target.id);
 				var lastScrollTop = target.scrollTop;
 				target.scrollTop = target.scrollHeight;
 				
@@ -66,10 +69,18 @@ var umbraIntervalFunc = function() {
 				}
 			}
 			else {
-				console.log("done scrolling for element of type " + target.nodeName + " with id of " + target.id)
+				console.log("done scrolling for element with nodeName " + target.nodeName + " with id of " + target.id)
 			} 
 			
 			umbraState.expectingSomething = null;
+		}
+		
+		if (thingsToScroll && thingsToScroll.length > 0 && everythingScrolled) {
+			if (umbraState.idleSince == null) {
+				umbraState.idleSince = Date.now();
+			}
+            
+			return;
 		}
 	
         var closeButtons = document.querySelectorAll('a[title="Close"], a.closeTheater');
@@ -151,10 +162,6 @@ var UMBRA_USER_ACTION_IDLE_TIMEOUT_SEC = 10;
 
 // Called from outside of this script.
 var umbraBehaviorFinished = function() {
-	
-	console.log("xx " + umbraState.idleSince);
-    var idleTimeMs = Date.now() - umbraState.idleSince;
-    console.log(idleTimeMs / 1000 > UMBRA_USER_ACTION_IDLE_TIMEOUT_SEC);
 	
         if (umbraState.idleSince != null) {
                 var idleTimeMs = Date.now() - umbraState.idleSince;


### PR DESCRIPTION
Enhancement is to allow capturing infinite scroll on the "likebox" facebook plugin, which is embedded in third party sites (example at: https://www.facebook.com/plugins/likebox.php?href=https%3A%2F%2Fwww.facebook.com%2FRep.HenryWaxman&show_faces=false&stream=true&header=false&width=284&frameborder=0&height=395 which is embedded in http://waxman.house.gov/ (right side)).

The css selector for the scrolling element in the plugin should be unique to just the plugin url so scrolling within this element should never happen on a "normal" facebook page. The plugin creates an iframe in which there is a div with scrollbars. This enhancement will detect its existence and then start scrolling until it detects an "end" condition (either the top has been scrolled as far as the div's height or there have been 5 attempts to scroll which haven't changed the top position).

I did a "normal" facebook crawl and there didn't seem to be any regressions to scrolling down a timeline. Not sure if there should be a separate behavior js for this behavior since it is very separate from the normal facebook page...
