### PR TITLE
Allow clicking on already clicked element to continue in behaviors if…

### DIFF
--- a/umbra/behaviors.d/simpleclicks.js.in
+++ b/umbra/behaviors.d/simpleclicks.js.in
@@ -8,7 +8,8 @@ var umbraBehavior = {
 		var somethingLeftBelow = false;
 		var somethingLeftAbove = false;
 		var cssSelector = "${click_css_selector}";
-
+		var clickUntilTimeout = "${click_until_hard_timeout}";
+		
 		var iframes = document.querySelectorAll("iframe");
 		var documents = Array(iframes.length + 1);
 		documents[0] = document;
@@ -22,7 +23,7 @@ var umbraBehavior = {
 			var clickTargets = documents[j].querySelectorAll(cssSelector);
 
 			for ( var i = 0; i < clickTargets.length; i++) {
-				if (clickTargets[i].umbraClicked) {
+				if (clickTargets[i].umbraClicked && !clickUntilTimeout) {
 					continue;
 				}
 

--- a/umbra/behaviors.d/simpleclicks.js.in
+++ b/umbra/behaviors.d/simpleclicks.js.in
@@ -9,6 +9,9 @@ var umbraBehavior = {
 		var somethingLeftAbove = false;
 		var cssSelector = "${click_css_selector}";
 		var clickUntilTimeout = "${click_until_hard_timeout}";
+
+		//handle Python to JavaScript boolean conversion
+		clickUntilTimeout == "True" ? clickUntilTimeout = true : clickUntilTimeout = false;
 		
 		var iframes = document.querySelectorAll("iframe");
 		var documents = Array(iframes.length + 1);

--- a/umbra/behaviors.py
+++ b/umbra/behaviors.py
@@ -32,7 +32,11 @@ class Behavior:
                     behavior_js = os.path.sep.join(__file__.split(os.path.sep)[:-1] + ["behaviors.d"] + [behavior["behavior_js"]])
                     behavior["script"] = open(behavior_js, encoding="utf-8").read()
                 elif "click_css_selector" in behavior:
-                    behavior["script"] = simpleclicks_js_template.substitute(click_css_selector=behavior["click_css_selector"])
+                    if "click_until_hard_timeout" in behavior: 
+                        click_until_hard_timeout_value=behavior["click_until_hard_timeout"]
+                    else:
+                        click_until_hard_timeout_value = False
+                    behavior["script"] = simpleclicks_js_template.substitute(click_css_selector=behavior["click_css_selector"], click_until_hard_timeout=click_until_hard_timeout_value)
 
         return Behavior._behaviors
 

--- a/umbra/behaviors.yaml
+++ b/umbra/behaviors.yaml
@@ -48,6 +48,11 @@ behaviors:
    url_regex: '^https?://(?:www\.)?youtube.com/.*$'
    click_css_selector: span.load-more-text
    request_idle_timeout_sec: 10
+ - # https://webarchive.jira.com/browse/ARI-4725
+   url_regex: '^https?://(?:www\.)?moma.org/.*$'
+   click_css_selector: button[data-more-results-bottom-button]
+   click_until_hard_timeout: True
+   request_idle_timeout_sec: 10   
  - # default fallback brhavior
    url_regex: '^.*$'
    request_idle_timeout_sec: 10


### PR DESCRIPTION
… click_until_hard_timeout is set to true. Add new behavior for http://www.moma.org/collection/artists and http://www.moma.org/collection to capture content revealed by clicking "Show more results" at the bottom of the page. Since the same "Show more results" button is reused by the site, we have to keep clicking on it. That is why the new behavior field click_until_hard_timeout was added.