### PR TITLE
Releaseable Browser pool allows Umbra to shut down all browsingThread…

### DIFF
--- a/umbra/ReleasableBrowserPool.py
+++ b/umbra/ReleasableBrowserPool.py
@@ -1,0 +1,10 @@
+from brozzler import BrowserPool
+
+
+class ReleasableBrowserPool(BrowserPool):
+
+    def release_everything(self):
+          for browser in  self._in_use:
+              browser.stop()  # make sure
+          with self._lock:
+              self._in_use.clear()


### PR DESCRIPTION
When we do a shutdown, we would like to shutdown all browsers, not just the ones we still have references to. 
It turned out that the browserpool did not have a release_all method (or rather it did have one, but this method took a list of the browsers to shut down). So I created a subclass that did have a release_all method