### PR TITLE
handle Network.responseReceived w/o requestHeaders

### DIFF
--- a/umbra/controller.py
+++ b/umbra/controller.py
@@ -201,20 +201,20 @@ class AmqpBrowserController:
             behavior_parameters=None, username=None, password=None):
         def on_response(chrome_msg):
             if (chrome_msg['params']['response']['url'].lower().startswith('data:')
-                    or chrome_msg['params']['response']['fromDiskCache']
-                    or not 'requestHeaders' in chrome_msg['params']['response']):
+                    or chrome_msg['params']['response']['fromDiskCache']):
                 return
 
+            request_headers = chrome_msg['params']['response'].get('requestHeaders', {})
             payload = {
                 'url': chrome_msg['params']['response']['url'],
-                'headers': chrome_msg['params']['response']['requestHeaders'],
+                'headers': request_headers,
                 'parentUrl': url,
                 'parentUrlMetadata': parent_url_metadata,
             }
 
-            if ':method' in chrome_msg['params']['response']['requestHeaders']:
+            if ':method' in request_headers:
                 # happens when http transaction is http 2.0
-                payload['method'] = chrome_msg['params']['response']['requestHeaders'][':method']
+                payload['method'] = request_headers[':method']
             elif 'requestHeadersText' in chrome_msg['params']['response']:
                 req = chrome_msg['params']['response']['requestHeadersText']
                 payload['method'] = req[:req.index(' ')]


### PR DESCRIPTION
Newer chromium is not including requestHeaders in
Network.responseReceived messages.
https://stackoverflow.com/questions/55842059/how-to-get-the-request-headers-using-the-chrome-devtool-protocol
Umbra was getting headers from Network.responseReceived instead of
Network.requestWillBeSent "because it has request info that we
need, like cookies" according to the commit message, see
https://github.com/internetarchive/umbra/commit/063a58d8539

We could switch back to Network.requestWillBeSent to be able to use a
subset of the headers. As of now I don't see a good way to get the
cookies though. There must be a way because you can still see cookies in
the chrome dev tools UI. But how much dev work does this warrant, when
brozzler is an option :)