### PR TITLE
deps: add Python 3.12 support

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,18 @@
+[project]
+name = "umbra"
+authors = [
+  { name="Noah Levitt", email="nlevitt@archive.org" },
+]
+maintainers = [
+  { name="Barbara Miller", email="barbara@archive.org" },
+  { name="Misty De Méo", email="misty@archive.org" },
+]
+description = "Queue-controlled browser automation tool for improving web crawl quality"
+readme = "README.md"
+requires-python = ">=3.8"
+classifiers = [
+    "Programming Language :: Python :: 3",
+    "License :: OSI Approved :: Apache Software License",
+    "Operating System :: OS Independent",
+]
+dynamic = [ "version", "license", "scripts", "dependencies", "optional-dependencies" ]

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,14 @@ setuptools.setup(
         long_description=open('README.md').read(),
         license='Apache License 2.0',
         packages=['umbra'],
-        install_requires=['brozzler>=1.1b9.dev201', 'kombu==3.0.37', 'PyYAML'],
+        install_requires=[
+            'brozzler>=1.1b9.dev201',
+            # yt-dlp and doublethink are optional brozzler dependencies
+            'yt-dlp>=2024.7.25',
+            'doublethink==0.4.10',
+            'kombu>=5.3.3, <6',
+            'PyYAML'
+        ],
         scripts=glob.glob('bin/*'),
         zip_safe=False,
         classifiers=[

--- a/umbra/__init__.py
+++ b/umbra/__init__.py
@@ -1,5 +1,5 @@
 from brozzler.browser import Browser
 from umbra.controller import AmqpBrowserController
-from pkg_resources import get_distribution as _get_distribution
-__version__ = _get_distribution('umbra').version
+from importlib.metadata import version as _version
+__version__ = _version('umbra')
 Umbra = AmqpBrowserController


### PR DESCRIPTION
This updates the dependencies for Python 3.12 support, along with few other changes:

* Bumps `kombu` from 3.0.37 to at least 5.3.3, which is the first version with Python 3.12 support: https://docs.celeryq.dev/projects/kombu/en/stable/changelog.html#version-5-3-3
* Adds doublethink and yt-dlp as brozzler dependencies; more recent versions of brozzler made these into extras, but the way Umbra calls brozzler means it needs them.
* Adds a basic `pyproject.toml`.

In local testing, it's looking good. I've done:

* Spin up a local rabbitmq at the default address
* Launch Umbra via `bin/umbra`
* Queue jobs via `bin/queue-url http://example.com`, and watch the Umbra process pick them up and process them 