### PR TITLE
release: umbra 2.2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "umbra"
-version = "2.1.dev10"
+version = "2.2"
 authors = [
   { name = "Eldon Stegall", email="eldon@archive.org" },
   { name="Noah Levitt", email="nlevitt@archive.org" },

--- a/uv.lock
+++ b/uv.lock
@@ -840,7 +840,7 @@ wheels = [
 
 [[package]]
 name = "umbra"
-version = "2.1.dev10"
+version = "2.2"
 source = { editable = "." }
 dependencies = [
     { name = "brozzler" },


### PR DESCRIPTION
With the packaging changes and new Sentry feature, seems worth tagging a new release. I'll create a `v2.2` tag when this is merged. Release notes:

This release introduces optional Sentry support for monitoring (#82). It also contains internal changes to Python packaging.