### PR TITLE
Add support for specifying a custom user agent

### DIFF
--- a/umbra/cli.py
+++ b/umbra/cli.py
@@ -33,6 +33,9 @@ def browse_url():
     arg_parser.add_argument('-e', '--executable', dest='chrome_exe',
             default=suggest_default_chrome_exe(),
             help='executable to use to invoke chrome')
+    arg_parser.add_argument('--user-agent', dest='user_agent',
+            default=None,
+            help='user agent to use when browsing')
     arg_parser.add_argument('-v', '--verbose', dest='log_level',
             action="store_const", default=logging.INFO, const=logging.DEBUG)
     arg_parser.add_argument('--version', action='version',
@@ -52,7 +55,8 @@ def browse_url():
         for url in args.urls:
             final_page_url, outlinks = browser.browse_page(
                     url, behavior_parameters=behavior_parameters,
-                    username=args.username, password=args.password)
+                    username=args.username, password=args.password,
+                    user_agent=args.user_agent)
             logger.info('Outlinks Found:\n\t%s', '\n\t'.join(outlinks))
 
 
@@ -181,6 +185,9 @@ def run_umbra():
             help='AMQP routing key to assign to AMQP queue of urls')
     arg_parser.add_argument('-n', '--max-browsers', dest='max_browsers', default='1',
             help='Max number of chrome instances simultaneously browsing pages')
+    arg_parser.add_argument('--user-agent', dest='user_agent',
+            default=None,
+            help='user agent to use when browsing')
     arg_parser.add_argument('-v', '--verbose', dest='log_level',
             action="store_const", default=logging.INFO, const=logging.DEBUG)
     arg_parser.add_argument('--version', action='version',
@@ -195,7 +202,7 @@ def run_umbra():
     controller = umbra.Umbra(args.amqp_url, args.chrome_exe,
             max_active_browsers=int(args.max_browsers),
             exchange_name=args.amqp_exchange, queue_name=args.amqp_queue,
-            routing_key=args.amqp_routing_key)
+            routing_key=args.amqp_routing_key, user_agent=args.user_agent)
 
     def browserdump_str(pp, b):
         x = []

--- a/umbra/controller.py
+++ b/umbra/controller.py
@@ -52,12 +52,14 @@ class AmqpBrowserController:
 
     def __init__(self, amqp_url='amqp://guest:guest@localhost:5672/%2f',
             chrome_exe='chromium-browser', max_active_browsers=1,
-            queue_name='urls', exchange_name='umbra', routing_key='urls'):
+            queue_name='urls', exchange_name='umbra', routing_key='urls',
+            user_agent=None):
         self.amqp_url = amqp_url
         self.queue_name = queue_name
         self.exchange_name = exchange_name
         self.routing_key = routing_key
         self.max_active_browsers = max_active_browsers
+        self.user_agent = user_agent
 
         self._browser_pool = BrowserPool(
                 size=max_active_browsers, chrome_exe=chrome_exe,
@@ -287,7 +289,8 @@ class AmqpBrowserController:
                 final_page_url, outlinks = browser.browse_page(
                         url, on_response=on_response,
                         behavior_parameters=behavior_parameters,
-                        username=username, password=password)
+                        username=username, password=password,
+                        user_agent=self.user_agent)
 
                 # Temporarily commenting out for https://webarchive.jira.com/browse/AITFIVE-1295
                 #post_outlinks(outlinks)


### PR DESCRIPTION
This has been supported by Brozzler since 1.6.10, but Umbra hasn't exposed a way to tweak that setting. This adds it to Umbra's CLI. When not specified, this will fall back on the default like in previous versions of Umbra.