### PR TITLE
release: 2.3.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "umbra"
-version = "2.2"
+version = "2.3"
 authors = [
   { name = "Eldon Stegall", email="eldon@archive.org" },
   { name="Noah Levitt", email="nlevitt@archive.org" },

--- a/uv.lock
+++ b/uv.lock
@@ -840,7 +840,7 @@ wheels = [
 
 [[package]]
 name = "umbra"
-version = "2.2"
+version = "2.3"
 source = { editable = "." }
 dependencies = [
     { name = "brozzler" },


### PR DESCRIPTION
This release adds a `--user-agent` commandline flag to the `queue-url` and `umbra` commandline tools to override Chrome's user agent.