### PR TITLE
metadata: use user agent from metadata if supplied

### DIFF
--- a/umbra/controller.py
+++ b/umbra/controller.py
@@ -281,6 +281,8 @@ class AmqpBrowserController:
                      publish(payload, exchange=self._exchange, routing_key=client_id)
 
         def browse_page_sync():
+            if "userAgent" in parent_url_metadata:
+                self.logger.info("Using custom user agent from metadata: %s", parent_url_metadata["userAgent"])
             user_agent = parent_url_metadata.get("userAgent", self.user_agent)
 
             self.logger.info(


### PR DESCRIPTION
This allows Heritrix to supply a user agent for the request. If passed, this will override Umbra's default user agent that was passed on the commandline when starting the server.