### PR TITLE
release: 2.4.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "umbra"
-version = "2.3"
+version = "2.4"
 authors = [
   { name = "Eldon Stegall", email="eldon@archive.org" },
   { name="Noah Levitt", email="nlevitt@archive.org" },

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.8"
 resolution-markers = [
     "python_full_version >= '3.9'",
@@ -840,7 +840,7 @@ wheels = [
 
 [[package]]
 name = "umbra"
-version = "2.3"
+version = "2.4"
 source = { editable = "." }
 dependencies = [
     { name = "brozzler" },


### PR DESCRIPTION
This releases enhances the user agent feature added in 2.3 by adding support for per-request user agents. If the `userAgent` key is present in the `metadata` passed to a request, Umbra will use that supplied user agent in place of the one that's configured at runtime. If no user agent is in `metadata`, Umbra will fall back to the global user agent.