### PR TITLE
sdnotify watchdog

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,8 @@ classifiers = [
 dependencies = [
   "brozzler>=1.6.10",
   "kombu>=5.3.3, <6",
-  "PyYAML"
+  "PyYAML",
+  "sdnotify>=0.3.2",
 ]
 
 [project.optional-dependencies]

--- a/umbra/__init__.py
+++ b/umbra/__init__.py
@@ -1,7 +1,8 @@
 from brozzler.browser import Browser  # noqa F401
 from umbra.controller import AmqpBrowserController
 from importlib.metadata import version as _version
-__version__ = _version('umbra')
+
+__version__ = _version("umbra")
 Umbra = AmqpBrowserController
 
 try:

--- a/umbra/cli.py
+++ b/umbra/cli.py
@@ -15,35 +15,72 @@ import json
 from kombu import Connection, Exchange, Queue
 from brozzler import suggest_default_chrome_exe
 
+
 def browse_url():
-    arg_parser = argparse.ArgumentParser(prog=os.path.basename(__file__),
-            description='browse-url - open urls in chrome/chromium and run behaviors',
-            formatter_class=argparse.ArgumentDefaultsHelpFormatter)
-    arg_parser.add_argument('urls', metavar='URL', nargs='+', help='URL(s) to browse')
-    arg_parser.add_argument('--behavior-parameters', dest='behavior_parameters',
-            default=None, help='json blob of parameters to use populate the javascript behavior template, e.g. {"parameter_username":"x","parameter_password":"y"}')
+    arg_parser = argparse.ArgumentParser(
+        prog=os.path.basename(__file__),
+        description="browse-url - open urls in chrome/chromium and run behaviors",
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+    )
+    arg_parser.add_argument("urls", metavar="URL", nargs="+", help="URL(s) to browse")
     arg_parser.add_argument(
-            '--username', dest='username', default=None,
-            help='use this username to try to log in if a login form is found')
+        "--behavior-parameters",
+        dest="behavior_parameters",
+        default=None,
+        help='json blob of parameters to use populate the javascript behavior template, e.g. {"parameter_username":"x","parameter_password":"y"}',
+    )
     arg_parser.add_argument(
-            '--password', dest='password', default=None,
-            help='use this password to try to log in if a login form is found')
-    arg_parser.add_argument('-w', '--browser-wait', dest='browser_wait', default='60',
-            help='seconds to wait for browser initialization')
-    arg_parser.add_argument('-e', '--executable', dest='chrome_exe',
-            default=suggest_default_chrome_exe(),
-            help='executable to use to invoke chrome')
-    arg_parser.add_argument('--user-agent', dest='user_agent',
-            default=None,
-            help='user agent to use when browsing')
-    arg_parser.add_argument('-v', '--verbose', dest='log_level',
-            action="store_const", default=logging.INFO, const=logging.DEBUG)
-    arg_parser.add_argument('--version', action='version',
-            version="umbra {} - {}".format(umbra.__version__, os.path.basename(__file__)))
+        "--username",
+        dest="username",
+        default=None,
+        help="use this username to try to log in if a login form is found",
+    )
+    arg_parser.add_argument(
+        "--password",
+        dest="password",
+        default=None,
+        help="use this password to try to log in if a login form is found",
+    )
+    arg_parser.add_argument(
+        "-w",
+        "--browser-wait",
+        dest="browser_wait",
+        default="60",
+        help="seconds to wait for browser initialization",
+    )
+    arg_parser.add_argument(
+        "-e",
+        "--executable",
+        dest="chrome_exe",
+        default=suggest_default_chrome_exe(),
+        help="executable to use to invoke chrome",
+    )
+    arg_parser.add_argument(
+        "--user-agent",
+        dest="user_agent",
+        default=None,
+        help="user agent to use when browsing",
+    )
+    arg_parser.add_argument(
+        "-v",
+        "--verbose",
+        dest="log_level",
+        action="store_const",
+        default=logging.INFO,
+        const=logging.DEBUG,
+    )
+    arg_parser.add_argument(
+        "--version",
+        action="version",
+        version="umbra {} - {}".format(umbra.__version__, os.path.basename(__file__)),
+    )
     args = arg_parser.parse_args(args=sys.argv[1:])
 
-    logging.basicConfig(stream=sys.stdout, level=args.log_level,
-            format='%(asctime)s %(process)d %(levelname)s %(threadName)s %(name)s.%(funcName)s(%(filename)s:%(lineno)d) %(message)s')
+    logging.basicConfig(
+        stream=sys.stdout,
+        level=args.log_level,
+        format="%(asctime)s %(process)d %(levelname)s %(threadName)s %(name)s.%(funcName)s(%(filename)s:%(lineno)d) %(message)s",
+    )
 
     logger = logging.getLogger(__name__)
 
@@ -54,34 +91,72 @@ def browse_url():
     with umbra.Browser(chrome_exe=args.chrome_exe) as browser:
         for url in args.urls:
             final_page_url, outlinks = browser.browse_page(
-                    url, behavior_parameters=behavior_parameters,
-                    username=args.username, password=args.password,
-                    user_agent=args.user_agent)
-            logger.info('Outlinks Found:\n\t%s', '\n\t'.join(outlinks))
+                url,
+                behavior_parameters=behavior_parameters,
+                username=args.username,
+                password=args.password,
+                user_agent=args.user_agent,
+            )
+            logger.info("Outlinks Found:\n\t%s", "\n\t".join(outlinks))
 
 
 def drain_queue():
-    arg_parser = argparse.ArgumentParser(prog=os.path.basename(__file__),
-            description='drain-queue - consume messages from AMQP queue',
-            formatter_class=argparse.ArgumentDefaultsHelpFormatter)
-    arg_parser.add_argument('-u', '--url', dest='amqp_url', default='amqp://guest:guest@localhost:5672/%2f',
-            help='URL identifying the AMQP server to talk to')
-    arg_parser.add_argument('--exchange', dest='amqp_exchange', default='umbra',
-            help='AMQP exchange name')
-    arg_parser.add_argument('--queue', dest='amqp_queue', default='urls',
-            help='AMQP queue name')
-    arg_parser.add_argument('-n', '--no-ack', dest='no_ack', action="store_const",
-            default=False, const=True, help="leave messages on the queue (default: remove them from the queue)")
-    arg_parser.add_argument('-r', '--run-forever', dest='run_forever', action="store_const",
-            default=False, const=True, help="run forever, waiting for new messages to appear on the queue (default: exit when all messages in the queue have been consumed)")
-    arg_parser.add_argument('-v', '--verbose', dest='log_level',
-            action="store_const", default=logging.INFO, const=logging.DEBUG)
-    arg_parser.add_argument('--version', action='version',
-            version="umbra {} - {}".format(umbra.__version__, os.path.basename(__file__)))
+    arg_parser = argparse.ArgumentParser(
+        prog=os.path.basename(__file__),
+        description="drain-queue - consume messages from AMQP queue",
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+    )
+    arg_parser.add_argument(
+        "-u",
+        "--url",
+        dest="amqp_url",
+        default="amqp://guest:guest@localhost:5672/%2f",
+        help="URL identifying the AMQP server to talk to",
+    )
+    arg_parser.add_argument(
+        "--exchange", dest="amqp_exchange", default="umbra", help="AMQP exchange name"
+    )
+    arg_parser.add_argument(
+        "--queue", dest="amqp_queue", default="urls", help="AMQP queue name"
+    )
+    arg_parser.add_argument(
+        "-n",
+        "--no-ack",
+        dest="no_ack",
+        action="store_const",
+        default=False,
+        const=True,
+        help="leave messages on the queue (default: remove them from the queue)",
+    )
+    arg_parser.add_argument(
+        "-r",
+        "--run-forever",
+        dest="run_forever",
+        action="store_const",
+        default=False,
+        const=True,
+        help="run forever, waiting for new messages to appear on the queue (default: exit when all messages in the queue have been consumed)",
+    )
+    arg_parser.add_argument(
+        "-v",
+        "--verbose",
+        dest="log_level",
+        action="store_const",
+        default=logging.INFO,
+        const=logging.DEBUG,
+    )
+    arg_parser.add_argument(
+        "--version",
+        action="version",
+        version="umbra {} - {}".format(umbra.__version__, os.path.basename(__file__)),
+    )
     args = arg_parser.parse_args(args=sys.argv[1:])
 
-    logging.basicConfig(stream=sys.stderr, level=args.log_level,
-            format='%(asctime)s %(process)d %(levelname)s %(threadName)s %(name)s.%(funcName)s(%(filename)s:%(lineno)d) %(message)s')
+    logging.basicConfig(
+        stream=sys.stderr,
+        level=args.log_level,
+        format="%(asctime)s %(process)d %(levelname)s %(threadName)s %(name)s.%(funcName)s(%(filename)s:%(lineno)d) %(message)s",
+    )
 
     def print_and_maybe_ack(body, message):
         # do this instead of print(body) so that output syntax is json, not python
@@ -91,7 +166,7 @@ def drain_queue():
         if not args.no_ack:
             message.ack()
 
-    exchange = Exchange(args.amqp_exchange, 'direct', durable=True)
+    exchange = Exchange(args.amqp_exchange, "direct", durable=True)
     queue = Queue(args.amqp_queue, exchange=exchange)
     try:
         with Connection(args.amqp_url) as conn:
@@ -109,100 +184,210 @@ def drain_queue():
 
 
 def queue_json():
-    arg_parser = argparse.ArgumentParser(prog=os.path.basename(__file__),
-            description='queue-json - send json message to umbra via AMQP',
-            formatter_class=argparse.ArgumentDefaultsHelpFormatter)
-    arg_parser.add_argument('-u', '--url', dest='amqp_url', default='amqp://guest:guest@localhost:5672/%2f',
-            help='URL identifying the AMQP server to talk to')
-    arg_parser.add_argument('--exchange', dest='amqp_exchange', default='umbra',
-            help='AMQP exchange name')
-    arg_parser.add_argument('--routing-key', dest='amqp_routing_key', default='urls',
-            help='AMQP routing key')
-    arg_parser.add_argument('-v', '--verbose', dest='log_level',
-            action="store_const", default=logging.INFO, const=logging.DEBUG)
-    arg_parser.add_argument('--version', action='version',
-            version="umbra {} - {}".format(umbra.__version__, os.path.basename(__file__)))
-    arg_parser.add_argument('payload_json', metavar='JSON_PAYLOAD', help='json payload to send to umbra')
+    arg_parser = argparse.ArgumentParser(
+        prog=os.path.basename(__file__),
+        description="queue-json - send json message to umbra via AMQP",
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+    )
+    arg_parser.add_argument(
+        "-u",
+        "--url",
+        dest="amqp_url",
+        default="amqp://guest:guest@localhost:5672/%2f",
+        help="URL identifying the AMQP server to talk to",
+    )
+    arg_parser.add_argument(
+        "--exchange", dest="amqp_exchange", default="umbra", help="AMQP exchange name"
+    )
+    arg_parser.add_argument(
+        "--routing-key",
+        dest="amqp_routing_key",
+        default="urls",
+        help="AMQP routing key",
+    )
+    arg_parser.add_argument(
+        "-v",
+        "--verbose",
+        dest="log_level",
+        action="store_const",
+        default=logging.INFO,
+        const=logging.DEBUG,
+    )
+    arg_parser.add_argument(
+        "--version",
+        action="version",
+        version="umbra {} - {}".format(umbra.__version__, os.path.basename(__file__)),
+    )
+    arg_parser.add_argument(
+        "payload_json", metavar="JSON_PAYLOAD", help="json payload to send to umbra"
+    )
     args = arg_parser.parse_args(args=sys.argv[1:])
 
-    logging.basicConfig(stream=sys.stdout, level=args.log_level,
-            format='%(asctime)s %(process)d %(levelname)s %(threadName)s %(name)s.%(funcName)s(%(filename)s:%(lineno)d) %(message)s')
+    logging.basicConfig(
+        stream=sys.stdout,
+        level=args.log_level,
+        format="%(asctime)s %(process)d %(levelname)s %(threadName)s %(name)s.%(funcName)s(%(filename)s:%(lineno)d) %(message)s",
+    )
 
     payload = json.loads(args.payload_json)
 
-    exchange = Exchange(args.amqp_exchange, 'direct', durable=True)
+    exchange = Exchange(args.amqp_exchange, "direct", durable=True)
     with Connection(args.amqp_url) as conn:
-        producer = conn.Producer(serializer='json')
-        logging.info("sending to amqp url={} exchange={} routing_key={} -- {}".format(args.amqp_url, args.amqp_exchange, args.amqp_routing_key, payload))
+        producer = conn.Producer(serializer="json")
+        logging.info(
+            "sending to amqp url={} exchange={} routing_key={} -- {}".format(
+                args.amqp_url, args.amqp_exchange, args.amqp_routing_key, payload
+            )
+        )
         producer.publish(payload, routing_key=args.amqp_routing_key, exchange=exchange)
 
 
 def queue_url():
-    arg_parser = argparse.ArgumentParser(prog=os.path.basename(__file__),
-            description='queue-url - send url to umbra via AMQP',
-            formatter_class=argparse.ArgumentDefaultsHelpFormatter)
-    arg_parser.add_argument('-u', '--url', dest='amqp_url', default='amqp://guest:guest@localhost:5672/%2f',
-            help='URL identifying the AMQP server to talk to')
-    arg_parser.add_argument('--exchange', dest='amqp_exchange', default='umbra',
-            help='AMQP exchange name')
-    arg_parser.add_argument('--routing-key', dest='amqp_routing_key', default='urls',
-            help='AMQP routing key')
-    arg_parser.add_argument('-i', '--client-id', dest='client_id', default='load_url.0',
-            help='client id - included in the json payload with each url; umbra uses this value as the routing key to send requests back to')
-    arg_parser.add_argument('-v', '--verbose', dest='log_level',
-            action="store_const", default=logging.INFO, const=logging.DEBUG)
-    arg_parser.add_argument('--version', action='version',
-            version="umbra {} - {}".format(umbra.__version__, os.path.basename(__file__)))
-    arg_parser.add_argument('urls', metavar='URL', nargs='+', help='URLs to send to umbra')
+    arg_parser = argparse.ArgumentParser(
+        prog=os.path.basename(__file__),
+        description="queue-url - send url to umbra via AMQP",
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+    )
+    arg_parser.add_argument(
+        "-u",
+        "--url",
+        dest="amqp_url",
+        default="amqp://guest:guest@localhost:5672/%2f",
+        help="URL identifying the AMQP server to talk to",
+    )
+    arg_parser.add_argument(
+        "--exchange", dest="amqp_exchange", default="umbra", help="AMQP exchange name"
+    )
+    arg_parser.add_argument(
+        "--routing-key",
+        dest="amqp_routing_key",
+        default="urls",
+        help="AMQP routing key",
+    )
+    arg_parser.add_argument(
+        "-i",
+        "--client-id",
+        dest="client_id",
+        default="load_url.0",
+        help="client id - included in the json payload with each url; umbra uses this value as the routing key to send requests back to",
+    )
+    arg_parser.add_argument(
+        "-v",
+        "--verbose",
+        dest="log_level",
+        action="store_const",
+        default=logging.INFO,
+        const=logging.DEBUG,
+    )
+    arg_parser.add_argument(
+        "--version",
+        action="version",
+        version="umbra {} - {}".format(umbra.__version__, os.path.basename(__file__)),
+    )
+    arg_parser.add_argument(
+        "urls", metavar="URL", nargs="+", help="URLs to send to umbra"
+    )
     args = arg_parser.parse_args(args=sys.argv[1:])
 
-    logging.basicConfig(stream=sys.stdout, level=args.log_level,
-            format='%(asctime)s %(process)d %(levelname)s %(threadName)s %(name)s.%(funcName)s(%(filename)s:%(lineno)d) %(message)s')
+    logging.basicConfig(
+        stream=sys.stdout,
+        level=args.log_level,
+        format="%(asctime)s %(process)d %(levelname)s %(threadName)s %(name)s.%(funcName)s(%(filename)s:%(lineno)d) %(message)s",
+    )
 
-    exchange = Exchange(args.amqp_exchange, 'direct', durable=True)
+    exchange = Exchange(args.amqp_exchange, "direct", durable=True)
     with Connection(args.amqp_url) as conn:
-        producer = conn.Producer(serializer='json')
+        producer = conn.Producer(serializer="json")
         for url in args.urls:
-            payload = {'url': url, 'metadata': {}, 'clientId': args.client_id}
-            logging.info("sending to amqp url={} exchange={} routing_key={} -- {}".format(args.amqp_url, args.amqp_exchange, args.amqp_routing_key, payload))
-            producer.publish(payload, routing_key=args.amqp_routing_key, exchange=exchange)
+            payload = {"url": url, "metadata": {}, "clientId": args.client_id}
+            logging.info(
+                "sending to amqp url={} exchange={} routing_key={} -- {}".format(
+                    args.amqp_url, args.amqp_exchange, args.amqp_routing_key, payload
+                )
+            )
+            producer.publish(
+                payload, routing_key=args.amqp_routing_key, exchange=exchange
+            )
 
 
 def run_umbra():
-    arg_parser = argparse.ArgumentParser(prog=os.path.basename(__file__),
-            description='umbra - browser automation tool communicating via AMQP',
-            formatter_class=argparse.ArgumentDefaultsHelpFormatter)
-    arg_parser.add_argument('-e', '--executable', dest='chrome_exe',
-            default=suggest_default_chrome_exe(),
-            help='Executable to use to invoke chrome')
-    arg_parser.add_argument('-u', '--url', dest='amqp_url', default='amqp://guest:guest@localhost:5672/%2f',
-            help='URL identifying the amqp server to talk to')
-    arg_parser.add_argument('--exchange', dest='amqp_exchange', default='umbra',
-            help='AMQP exchange name')
-    arg_parser.add_argument('--queue', dest='amqp_queue', default='urls',
-            help='AMQP queue to consume urls from')
-    arg_parser.add_argument('--routing-key', dest='amqp_routing_key', default='urls',
-            help='AMQP routing key to assign to AMQP queue of urls')
-    arg_parser.add_argument('-n', '--max-browsers', dest='max_browsers', default='1',
-            help='Max number of chrome instances simultaneously browsing pages')
-    arg_parser.add_argument('--user-agent', dest='user_agent',
-            default=None,
-            help='user agent to use when browsing')
-    arg_parser.add_argument('-v', '--verbose', dest='log_level',
-            action="store_const", default=logging.INFO, const=logging.DEBUG)
-    arg_parser.add_argument('--version', action='version',
-            version="umbra {}".format(umbra.__version__))
+    arg_parser = argparse.ArgumentParser(
+        prog=os.path.basename(__file__),
+        description="umbra - browser automation tool communicating via AMQP",
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+    )
+    arg_parser.add_argument(
+        "-e",
+        "--executable",
+        dest="chrome_exe",
+        default=suggest_default_chrome_exe(),
+        help="Executable to use to invoke chrome",
+    )
+    arg_parser.add_argument(
+        "-u",
+        "--url",
+        dest="amqp_url",
+        default="amqp://guest:guest@localhost:5672/%2f",
+        help="URL identifying the amqp server to talk to",
+    )
+    arg_parser.add_argument(
+        "--exchange", dest="amqp_exchange", default="umbra", help="AMQP exchange name"
+    )
+    arg_parser.add_argument(
+        "--queue",
+        dest="amqp_queue",
+        default="urls",
+        help="AMQP queue to consume urls from",
+    )
+    arg_parser.add_argument(
+        "--routing-key",
+        dest="amqp_routing_key",
+        default="urls",
+        help="AMQP routing key to assign to AMQP queue of urls",
+    )
+    arg_parser.add_argument(
+        "-n",
+        "--max-browsers",
+        dest="max_browsers",
+        default="1",
+        help="Max number of chrome instances simultaneously browsing pages",
+    )
+    arg_parser.add_argument(
+        "--user-agent",
+        dest="user_agent",
+        default=None,
+        help="user agent to use when browsing",
+    )
+    arg_parser.add_argument(
+        "-v",
+        "--verbose",
+        dest="log_level",
+        action="store_const",
+        default=logging.INFO,
+        const=logging.DEBUG,
+    )
+    arg_parser.add_argument(
+        "--version", action="version", version="umbra {}".format(umbra.__version__)
+    )
     args = arg_parser.parse_args(args=sys.argv[1:])
 
-    logging.basicConfig(stream=sys.stdout, level=args.log_level,
-            format='%(asctime)s %(process)d %(levelname)s %(threadName)s %(name)s.%(funcName)s(%(filename)s:%(lineno)d) %(message)s')
+    logging.basicConfig(
+        stream=sys.stdout,
+        level=args.log_level,
+        format="%(asctime)s %(process)d %(levelname)s %(threadName)s %(name)s.%(funcName)s(%(filename)s:%(lineno)d) %(message)s",
+    )
 
     logging.info("umbra {} starting up".format(umbra.__version__))
 
-    controller = umbra.Umbra(args.amqp_url, args.chrome_exe,
-            max_active_browsers=int(args.max_browsers),
-            exchange_name=args.amqp_exchange, queue_name=args.amqp_queue,
-            routing_key=args.amqp_routing_key, user_agent=args.user_agent)
+    controller = umbra.Umbra(
+        args.amqp_url,
+        args.chrome_exe,
+        max_active_browsers=int(args.max_browsers),
+        exchange_name=args.amqp_exchange,
+        queue_name=args.amqp_queue,
+        routing_key=args.amqp_routing_key,
+        user_agent=args.user_agent,
+    )
 
     def browserdump_str(pp, b):
         x = []
@@ -233,16 +418,18 @@ def run_umbra():
             state_strs.append(browserdump_str(pp, b))
             state_strs.append("")
 
-        logging.warn("dumping state (caught signal {})\n{}".format(signum, "\n".join(state_strs)))
-
+        logging.warn(
+            "dumping state (caught signal {})\n{}".format(signum, "\n".join(state_strs))
+        )
 
     class ShutdownRequested(Exception):
         pass
 
     def sigterm(signum, frame):
-        raise ShutdownRequested('shutdown requested (caught SIGTERM)')
+        raise ShutdownRequested("shutdown requested (caught SIGTERM)")
+
     def sigint(signum, frame):
-        raise ShutdownRequested('shutdown requested (caught SIGINT)')
+        raise ShutdownRequested("shutdown requested (caught SIGINT)")
 
     signal.signal(signal.SIGQUIT, dump_state)
     signal.signal(signal.SIGHUP, controller.reconnect)

--- a/umbra/controller.py
+++ b/umbra/controller.py
@@ -7,10 +7,13 @@ import time
 import threading
 import kombu
 import socket
+import sdnotify
 from brozzler.browser import BrowserPool, BrowsingException
 import brozzler
 import urlcanon
 
+_sd = sdnotify.SystemdNotifier()
+_WATCHDOG_INTERVAL_SECONDS = 60
 
 class AmqpBrowserController:
     """
@@ -93,6 +96,7 @@ class AmqpBrowserController:
         )
         self._consumer_stop = threading.Event()
         self._consumer_thread.start()
+        _sd.notify("READY=1")
 
     def shutdown(self):
         self.logger.info("shutting down amqp consumer {}".format(self.amqp_url))
@@ -116,6 +120,7 @@ class AmqpBrowserController:
     def _wait_for_and_browse_urls(self, conn, consumer, timeout):
         start = time.time()
         browser = None
+        _last_watchdog_ping = 0
 
         while (
             not self._consumer_stop.is_set()
@@ -154,6 +159,7 @@ class AmqpBrowserController:
                         username,
                         password,
                     )
+                    _sd.notify("WATCHDOG=1")
 
                 consumer.callbacks = [callback]
 
@@ -162,7 +168,10 @@ class AmqpBrowserController:
                         conn.drain_events(timeout=0.5)
                         break  # out of "while True" to acquire another browser
                     except socket.timeout:
-                        pass
+                        now = time.time()
+                        if now - _last_watchdog_ping > _WATCHDOG_INTERVAL_SECONDS:
+                            _last_watchdog_ping = now
+                            _sd.notify("WATCHDOG=1")
                     except socket.error:
                         self.logger.error(
                             "problem consuming messages from AMQP, will try reconnecting after active browsing finishes",

--- a/umbra/controller.py
+++ b/umbra/controller.py
@@ -11,6 +11,7 @@ from brozzler.browser import BrowserPool, BrowsingException
 import brozzler
 import urlcanon
 
+
 class AmqpBrowserController:
     """
     Consumes amqp messages representing requests to browse urls, from the
@@ -50,10 +51,16 @@ class AmqpBrowserController:
 
     logger = logging.getLogger(__module__ + "." + __qualname__)
 
-    def __init__(self, amqp_url='amqp://guest:guest@localhost:5672/%2f',
-            chrome_exe='chromium-browser', max_active_browsers=1,
-            queue_name='urls', exchange_name='umbra', routing_key='urls',
-            user_agent=None):
+    def __init__(
+        self,
+        amqp_url="amqp://guest:guest@localhost:5672/%2f",
+        chrome_exe="chromium-browser",
+        max_active_browsers=1,
+        queue_name="urls",
+        exchange_name="umbra",
+        routing_key="urls",
+        user_agent=None,
+    ):
         self.amqp_url = amqp_url
         self.queue_name = queue_name
         self.exchange_name = exchange_name
@@ -62,15 +69,16 @@ class AmqpBrowserController:
         self.user_agent = user_agent
 
         self._browser_pool = BrowserPool(
-                size=max_active_browsers, chrome_exe=chrome_exe,
-                ignore_cert_errors=True)
+            size=max_active_browsers, chrome_exe=chrome_exe, ignore_cert_errors=True
+        )
 
     def start(self):
         self._browsing_threads = set()
         self._browsing_threads_lock = threading.Lock()
 
-        self._exchange = kombu.Exchange(name=self.exchange_name, type='direct',
-                durable=True)
+        self._exchange = kombu.Exchange(
+            name=self.exchange_name, type="direct", durable=True
+        )
 
         self._reconnect_requested = False
 
@@ -78,9 +86,11 @@ class AmqpBrowserController:
         self._producer_lock = threading.Lock()
         with self._producer_lock:
             self._producer_conn = kombu.Connection(self.amqp_url)
-            self._producer = self._producer_conn.Producer(serializer='json')
+            self._producer = self._producer_conn.Producer(serializer="json")
 
-        self._consumer_thread = threading.Thread(target=self._consume_amqp, name='AmqpConsumerThread')
+        self._consumer_thread = threading.Thread(
+            target=self._consume_amqp, name="AmqpConsumerThread"
+        )
         self._consumer_stop = threading.Event()
         self._consumer_thread.start()
 
@@ -107,43 +117,64 @@ class AmqpBrowserController:
         start = time.time()
         browser = None
 
-        while not self._consumer_stop.is_set() and time.time() - start < timeout and not self._reconnect_requested:
+        while (
+            not self._consumer_stop.is_set()
+            and time.time() - start < timeout
+            and not self._reconnect_requested
+        ):
             try:
-                browser = self._browser_pool.acquire() # raises KeyError if none available
+                browser = (
+                    self._browser_pool.acquire()
+                )  # raises KeyError if none available
 
                 def callback(body, message):
                     try:
-                        client_id = body.get('clientId')
-                        url = body['url']
-                        metadata = body.get('metadata')
-                        behavior_parameters = body.get('behaviorParameters')
-                        username = body.get('username')
-                        password = body.get('password')
+                        client_id = body.get("clientId")
+                        url = body["url"]
+                        metadata = body.get("metadata")
+                        behavior_parameters = body.get("behaviorParameters")
+                        username = body.get("username")
+                        password = body.get("password")
                     except KeyError:
-                        self.logger.error("unable to decipher message %s",
-                                          message, exc_info=True)
+                        self.logger.error(
+                            "unable to decipher message %s", message, exc_info=True
+                        )
                         self.logger.error("discarding bad message")
                         message.reject()
                         browser.stop()
                         self._browser_pool.release(browser)
                         return
                     self._start_browsing_page(
-                            browser, message, client_id, url, metadata,
-                            behavior_parameters, username, password)
+                        browser,
+                        message,
+                        client_id,
+                        url,
+                        metadata,
+                        behavior_parameters,
+                        username,
+                        password,
+                    )
 
                 consumer.callbacks = [callback]
 
                 while True:
                     try:
                         conn.drain_events(timeout=0.5)
-                        break # out of "while True" to acquire another browser
+                        break  # out of "while True" to acquire another browser
                     except socket.timeout:
                         pass
                     except socket.error:
-                        self.logger.error("problem consuming messages from AMQP, will try reconnecting after active browsing finishes", exc_info=True)
+                        self.logger.error(
+                            "problem consuming messages from AMQP, will try reconnecting after active browsing finishes",
+                            exc_info=True,
+                        )
                         self._reconnect_requested = True
 
-                    if self._consumer_stop.is_set() or time.time() - start >= timeout or self._reconnect_requested:
+                    if (
+                        self._consumer_stop.is_set()
+                        or time.time() - start >= timeout
+                        or self._reconnect_requested
+                    ):
                         browser.stop()
                         self._browser_pool.release(browser)
                         break
@@ -152,7 +183,9 @@ class AmqpBrowserController:
                 # no browsers available
                 time.sleep(0.5)
             except Exception:
-                self.logger.critical("problem with browser initialization", exc_info=True)
+                self.logger.critical(
+                    "problem with browser initialization", exc_info=True
+                )
                 time.sleep(0.5)
             finally:
                 consumer.callbacks = None
@@ -175,19 +208,28 @@ class AmqpBrowserController:
         # reopen the connection every 2.5 hours
         RECONNECT_AFTER_SECONDS = 150 * 60
 
-        url_queue = kombu.Queue(self.queue_name, exchange=self._exchange, routing_key=self.routing_key)
+        url_queue = kombu.Queue(
+            self.queue_name, exchange=self._exchange, routing_key=self.routing_key
+        )
 
         while not self._consumer_stop.is_set():
             try:
-                self.logger.info("connecting to amqp exchange={} at {}".format(self._exchange.name, self.amqp_url))
+                self.logger.info(
+                    "connecting to amqp exchange={} at {}".format(
+                        self._exchange.name, self.amqp_url
+                    )
+                )
                 self._reconnect_requested = False
                 with kombu.Connection(self.amqp_url) as conn:
                     conn.default_channel.basic_qos(
-                            prefetch_count=self.max_active_browsers,
-                            prefetch_size=0, a_global=False)
+                        prefetch_count=self.max_active_browsers,
+                        prefetch_size=0,
+                        a_global=False,
+                    )
                     with conn.Consumer(url_queue) as consumer:
                         self._wait_for_and_browse_urls(
-                                conn, consumer, timeout=RECONNECT_AFTER_SECONDS)
+                            conn, consumer, timeout=RECONNECT_AFTER_SECONDS
+                        )
 
                     # need to wait for browsers to finish here, before closing
                     # the amqp connection,  because they use it to do
@@ -199,118 +241,165 @@ class AmqpBrowserController:
                 self.logger.error("attempting to reopen amqp connection")
 
     def _start_browsing_page(
-            self, browser, message, client_id, url, parent_url_metadata,
-            behavior_parameters=None, username=None, password=None):
+        self,
+        browser,
+        message,
+        client_id,
+        url,
+        parent_url_metadata,
+        behavior_parameters=None,
+        username=None,
+        password=None,
+    ):
         def on_response(chrome_msg):
-            if (chrome_msg['params']['response']['url'].lower().startswith('data:')
-                    or chrome_msg['params']['response']['fromDiskCache']):
+            if (
+                chrome_msg["params"]["response"]["url"].lower().startswith("data:")
+                or chrome_msg["params"]["response"]["fromDiskCache"]
+            ):
                 return
 
-            request_headers = chrome_msg['params']['response'].get('requestHeaders', {})
+            request_headers = chrome_msg["params"]["response"].get("requestHeaders", {})
             payload = {
-                'url': chrome_msg['params']['response']['url'],
-                'headers': request_headers,
-                'parentUrl': url,
-                'parentUrlMetadata': parent_url_metadata,
+                "url": chrome_msg["params"]["response"]["url"],
+                "headers": request_headers,
+                "parentUrl": url,
+                "parentUrlMetadata": parent_url_metadata,
             }
 
-            if ':method' in request_headers:
+            if ":method" in request_headers:
                 # happens when http transaction is http 2.0
-                payload['method'] = request_headers[':method']
-            elif 'requestHeadersText' in chrome_msg['params']['response']:
-                req = chrome_msg['params']['response']['requestHeadersText']
-                payload['method'] = req[:req.index(' ')]
+                payload["method"] = request_headers[":method"]
+            elif "requestHeadersText" in chrome_msg["params"]["response"]:
+                req = chrome_msg["params"]["response"]["requestHeadersText"]
+                payload["method"] = req[: req.index(" ")]
             else:
-                self.logger.warn('unable to identify http method (assuming GET) chrome_msg=%s',
-                                 chrome_msg)
-                payload['method'] = 'GET'
+                self.logger.warn(
+                    "unable to identify http method (assuming GET) chrome_msg=%s",
+                    chrome_msg,
+                )
+                payload["method"] = "GET"
 
             self.logger.debug(
-                    'sending to amqp exchange=%s routing_key=%s payload=%s',
-                    self.exchange_name, client_id, payload)
+                "sending to amqp exchange=%s routing_key=%s payload=%s",
+                self.exchange_name,
+                client_id,
+                payload,
+            )
             with self._producer_lock:
-                publish = self._producer_conn.ensure(self._producer,
-                                                     self._producer.publish)
+                publish = self._producer_conn.ensure(
+                    self._producer, self._producer.publish
+                )
                 publish(payload, exchange=self._exchange, routing_key=client_id)
 
         def post_outlinks(outlinks=None):
             def prune_outlinks(dirty_links, block_list=None):
-                '''
+                """
                 Filter for valid schemes, remove URL fragments, and drop any other designated URLs from the list.
-                '''
+                """
                 links = set()
                 dirty_links = set(dirty_links)
 
-                self.logger.info('Pruning links...')
+                self.logger.info("Pruning links...")
                 for link in dirty_links:
                     link = urlcanon.parse_url(link)
 
-                    if link.scheme in (b'http', b'https', b'ftp'):
+                    if link.scheme in (b"http", b"https", b"ftp"):
                         urlcanon.canon.remove_fragment(link)
                         link = str(link).strip()
                         links.add(link)
 
-                self.logger.info('Pruning complete.')
+                self.logger.info("Pruning complete.")
 
                 # Need to remove after link fragments have been removed to prevent duplication.
-                self.logger.info('Removing Links: %s', ', '.join(block_list))
+                self.logger.info("Removing Links: %s", ", ".join(block_list))
                 links = links.difference(block_list)
 
                 return links
 
             outlinks = prune_outlinks(outlinks, {url})
 
-            self.logger.info('Posting Outlinks:\n\t%s', '\n\t'.join(sorted(outlinks)))
+            self.logger.info("Posting Outlinks:\n\t%s", "\n\t".join(sorted(outlinks)))
 
             for link in outlinks:
-                 #  Each of these payload fields are required by AMQPUrlReceiver.java
-                 #+ in Heritrix.
-                 payload = {
-                    'url': link,
-                    'headers': {},
-                    'parentUrl': url,
-                    'parentUrlMetadata': parent_url_metadata,
-                    'method': 'GET',
-                 }
-                 self.logger.debug(
-                            'sending outlink to amqp exchange=%s routing_key=%s payload=%s',
-                            self.exchange_name, client_id, payload)
-                 with self._producer_lock:
-                     publish = self._producer_conn.ensure(self._producer,
-                                                          self._producer.publish)
-                     publish(payload, exchange=self._exchange, routing_key=client_id)
+                #  Each of these payload fields are required by AMQPUrlReceiver.java
+                # + in Heritrix.
+                payload = {
+                    "url": link,
+                    "headers": {},
+                    "parentUrl": url,
+                    "parentUrlMetadata": parent_url_metadata,
+                    "method": "GET",
+                }
+                self.logger.debug(
+                    "sending outlink to amqp exchange=%s routing_key=%s payload=%s",
+                    self.exchange_name,
+                    client_id,
+                    payload,
+                )
+                with self._producer_lock:
+                    publish = self._producer_conn.ensure(
+                        self._producer, self._producer.publish
+                    )
+                    publish(payload, exchange=self._exchange, routing_key=client_id)
 
         def browse_page_sync():
             if "userAgent" in parent_url_metadata:
-                self.logger.info("Using custom user agent from metadata: %s", parent_url_metadata["userAgent"])
+                self.logger.info(
+                    "Using custom user agent from metadata: %s",
+                    parent_url_metadata["userAgent"],
+                )
             user_agent = parent_url_metadata.get("userAgent", self.user_agent)
 
             self.logger.info(
-                    'browser=%s client_id=%s url=%s behavior_parameters=%s',
-                    browser, client_id, url, behavior_parameters)
+                "browser=%s client_id=%s url=%s behavior_parameters=%s",
+                browser,
+                client_id,
+                url,
+                behavior_parameters,
+            )
             try:
                 browser.start()
                 final_page_url, outlinks = browser.browse_page(
-                        url, on_response=on_response,
-                        behavior_parameters=behavior_parameters,
-                        username=username, password=password,
-                        user_agent=user_agent)
+                    url,
+                    on_response=on_response,
+                    behavior_parameters=behavior_parameters,
+                    username=username,
+                    password=password,
+                    user_agent=user_agent,
+                )
 
                 # Temporarily commenting out for https://webarchive.jira.com/browse/AITFIVE-1295
-                #post_outlinks(outlinks)
+                # post_outlinks(outlinks)
 
                 message.ack()
             except brozzler.PageInterstitialShown as e:
-                self.logger.info("page interstitial shown, likely unsupported http auth, for url {} - {}".format(url, e))
+                self.logger.info(
+                    "page interstitial shown, likely unsupported http auth, for url {} - {}".format(
+                        url, e
+                    )
+                )
                 message.reject()
             except brozzler.ShutdownRequested as e:
-                self.logger.info("browsing did not complete normally, requeuing url {} - {}".format(url, e))
+                self.logger.info(
+                    "browsing did not complete normally, requeuing url {} - {}".format(
+                        url, e
+                    )
+                )
                 message.requeue()  # republish?
             except BrowsingException as e:
-                self.logger.warn("browsing did not complete normally, republishing url {} - {}".format(url, e))
+                self.logger.warn(
+                    "browsing did not complete normally, republishing url {} - {}".format(
+                        url, e
+                    )
+                )
                 republish_amqp(self, message)
             except Exception:
-                self.logger.critical("problem browsing page, republishing url {}, may have lost browser process".format(url), exc_info=True)
+                self.logger.critical(
+                    "problem browsing page, republishing url {}, may have lost browser process".format(
+                        url
+                    ),
+                    exc_info=True,
+                )
                 republish_amqp(self, message)
             finally:
                 browser.stop()
@@ -321,40 +410,44 @@ class AmqpBrowserController:
             payload = json.loads(to_str(message.body))
             message.ack()
             max_retries = 5
-            if 'metadata' in payload:
-                if 'retries' not in payload['metadata']:
-                    payload['metadata']['retries'] = 1
+            if "metadata" in payload:
+                if "retries" not in payload["metadata"]:
+                    payload["metadata"]["retries"] = 1
                 else:
-                    if payload['metadata']['retries'] >= max_retries:
+                    if payload["metadata"]["retries"] >= max_retries:
                         return
-                    payload['metadata']['retries'] += 1
+                    payload["metadata"]["retries"] += 1
             self.logger.debug(
-                       're-publishing url to amqp exchange=%s routing_key=%s payload=%s',
-                       self.exchange_name, self.routing_key, payload)
+                "re-publishing url to amqp exchange=%s routing_key=%s payload=%s",
+                self.exchange_name,
+                self.routing_key,
+                payload,
+            )
             with self._producer_lock:
-                publish = self._producer_conn.ensure(self._producer,
-                                                     self._producer.publish)
+                publish = self._producer_conn.ensure(
+                    self._producer, self._producer.publish
+                )
                 publish(payload, exchange=self._exchange, routing_key=self.routing_key)
 
         def to_str(bytes_or_str):
             if isinstance(bytes_or_str, bytes):
-                value = bytes_or_str.decode() # uses 'utf-8' for encoding
+                value = bytes_or_str.decode()  # uses 'utf-8' for encoding
             else:
                 value = bytes_or_str
-            return value # Instance of str
+            return value  # Instance of str
 
         def browse_thread_run_then_cleanup():
             browse_page_sync()
             self.logger.info(
-                    'removing thread %s from self._browsing_threads',
-                    threading.current_thread())
+                "removing thread %s from self._browsing_threads",
+                threading.current_thread(),
+            )
             with self._browsing_threads_lock:
                 self._browsing_threads.remove(threading.current_thread())
 
         thread_name = "BrowsingThread:%s" % browser.chrome.port
         th = threading.Thread(target=browse_thread_run_then_cleanup, name=thread_name)
-        self.logger.info('adding thread %s to self._browsing_threads', th)
+        self.logger.info("adding thread %s to self._browsing_threads", th)
         with self._browsing_threads_lock:
             self._browsing_threads.add(th)
         th.start()
-

--- a/uv.lock
+++ b/uv.lock
@@ -786,6 +786,12 @@ wheels = [
 ]
 
 [[package]]
+name = "sdnotify"
+version = "0.3.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ce/d8/9fdc36b2a912bf78106de4b3f0de3891ff8f369e7a6f80be842b8b0b6bd5/sdnotify-0.3.2.tar.gz", hash = "sha256:73977fc746b36cc41184dd43c3fe81323e7b8b06c2bb0826c4f59a20c56bb9f1", size = 2459, upload-time = "2017-08-02T20:03:44.395Z" }
+
+[[package]]
 name = "sentry-sdk"
 version = "2.34.1"
 source = { registry = "https://pypi.org/simple" }
@@ -846,6 +852,7 @@ dependencies = [
     { name = "brozzler" },
     { name = "kombu" },
     { name = "pyyaml" },
+    { name = "sdnotify" },
 ]
 
 [package.optional-dependencies]
@@ -863,6 +870,7 @@ requires-dist = [
     { name = "brozzler", specifier = ">=1.6.10" },
     { name = "kombu", specifier = ">=5.3.3,<6" },
     { name = "pyyaml" },
+    { name = "sdnotify", specifier = ">=0.3.2" },
     { name = "sentry-sdk", marker = "extra == 'sentry'", specifier = ">=2.34.1" },
 ]
 provides-extras = ["sentry"]


### PR DESCRIPTION
Sometimes umbra instances get stuck without completely dying. On systemd deployments we can use the Watchdog and sdnotify to automatically restart umbra whenever it fails to ping sdnotify for `WatchdogSec`. sdnotify fails silently on non-systemd deployments, so we don't need to gate this as an optional dependency.

I also did a ruff pass, breaking this work into two commits to make it easy to see the sdnotify changes.